### PR TITLE
Adicionar palestras nos eventos

### DIFF
--- a/eventos/admin.py
+++ b/eventos/admin.py
@@ -1,21 +1,38 @@
+#-*- coding: utf-8 -*-
 from django.contrib import admin
 
 from eventos.models import (Evento, Profile, Inscricao,
                             Palestra, Realizacao, Patrocinio)
 
+class PalestraInline(admin.TabularInline):
+    model = Palestra
+    extra = 3
 
 class EventoAdmin(admin.ModelAdmin):
-    prepopulated_fields = {"slug": ("titulo",)}
+    fieldsets = [
+        (None,                     {'fields': ['titulo']}),
+        ('Informações sobre data', {'fields': ['data_realizacao'], 'classes': ['collapse']}),
+    ]
+    inlines = [PalestraInline]
+
     list_display = ('titulo', 'data_realizacao', 'publicado')
+    list_filter = ['data_realizacao']
+    search_fields = ['titulo'] # pode-se colocar mais de um, porém MAKE IT SIMPLE
+    date_hierarchy = 'data_realizacao'
+
+
+# class EventoAdmin(admin.ModelAdmin):
+#     prepopulated_fields = {"slug": ("titulo",)}
+#     list_display = ('titulo', 'data_realizacao', 'publicado')
 
 
 class ProfileAdmin(admin.ModelAdmin):
     list_display = ('nome', 'email')
 
 
-class PalestraAdmin(admin.ModelAdmin):
-    list_display = ('titulo', 'evento')
-    prepopulated_fields = {"slug": ("titulo",)}
+# class PalestraAdmin(admin.ModelAdmin):
+#     list_display = ('titulo', 'evento')
+#     prepopulated_fields = {"slug": ("titulo",)}
 
 
 class PatrocinioAdmin(admin.ModelAdmin):
@@ -24,7 +41,7 @@ class PatrocinioAdmin(admin.ModelAdmin):
 
 admin.site.register(Evento, EventoAdmin)
 admin.site.register(Profile, ProfileAdmin)
-admin.site.register(Palestra, PalestraAdmin)
+#admin.site.register(Palestra, PalestraAdmin)
 admin.site.register(Patrocinio, PatrocinioAdmin)
 admin.site.register(Inscricao)
 admin.site.register(Realizacao)


### PR DESCRIPTION
Alterada a maneira como adicionar uma Palestra. É possível adicionar palestras diretamente no evento. Além disso, foi colocado um filtro por data de realização, adicionada a navegação por data (ano, mês, dia) e uma caixa de pesquisa por título.
